### PR TITLE
Adapt renderers demo to latest changes

### DIFF
--- a/demos/renderers/main.lua
+++ b/demos/renderers/main.lua
@@ -14,9 +14,9 @@ local function load(svg)
 
 	-- just some glue code for presentation.
 	flow = tovedemo.newCoverFlow()
-	for _, mode in ipairs {"texture", "mesh", "shader"} do
+	for _, mode in ipairs {"texture", "mesh", "gpux"} do
 		local graphics = newGraphics()
-		graphics:setDisplay(mode)
+		graphics:setDisplay(mode, 200)
 		flow:add(mode, graphics)
 	end
 end


### PR DESCRIPTION
I think the documentation would need to be changed as well (it still mentions that the quality is a value between 0 and 1: https://github.com/poke1024/tove2d/blob/master/docs/Renderers.md)