### PR TITLE
Check for both "+/-" and "kp+/kp-" constants in editor demo

### DIFF
--- a/demos/editor/demo.lua
+++ b/demos/editor/demo.lua
@@ -83,10 +83,10 @@ function Demo:keypressed(key, scancode, isrepeat)
     if key == "a" then
         self.animation = not self.animation
     end
-    if key == "+" then
+    if key == "+" or key == "kp+" then
         self:addObjects()
     end
-    if key == "-" then
+    if key == "-" or key == "kp-" then
         self:removeObjects()
     end
 end


### PR DESCRIPTION
For some reason, the +/- constants would not work on my machine... So, we can check for kp+ and kp- as well.