### PR TITLE
Add C++ API demo

### DIFF
--- a/demos/cpp/.gitignore
+++ b/demos/cpp/.gitignore
@@ -1,0 +1,2 @@
+cpp
+frames

--- a/demos/cpp/README.md
+++ b/demos/cpp/README.md
@@ -1,0 +1,3 @@
+This demo shows how to use TÖVE from C++ code.
+
+It renders an SVG animation to PNG files by using the `stb_image_write` library.

--- a/demos/cpp/SConstruct
+++ b/demos/cpp/SConstruct
@@ -1,8 +1,7 @@
-libtove = File('../../tove/libtove.a')
-
 Program("cpp", ['main.cpp'], 
 	CPPPATH = [
 		'../../src/thirdparty/fp16/include',
 		'../../src/thirdparty/nanosvg/example',
 		'../../src/cpp/'], 
-	LIBS = [libtove])
+	LIBS = ["tove"],
+	LIBPATH = ["../../tove"])

--- a/demos/cpp/SConstruct
+++ b/demos/cpp/SConstruct
@@ -1,0 +1,8 @@
+libtove = File('../../tove/libtove.a')
+
+Program("cpp", ['main.cpp'], 
+	CPPPATH = [
+		'../../src/thirdparty/fp16/include',
+		'../../src/thirdparty/nanosvg/example',
+		'../../src/cpp/'], 
+	LIBS = [libtove])

--- a/demos/cpp/gradient-circle/gradient-circle_00001.svg
+++ b/demos/cpp/gradient-circle/gradient-circle_00001.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Moho 12.4 build 22203 -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Frame_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1280px" height="720px">
+<linearGradient id="6131A9E2-CA9E-49F0-9B44-3AD4FEE82BAF_0" x1="65.08%" y1="76.70%" x2="7.98%" y2="41.45%">
+<stop offset="0.00%" style="stop-color:rgb(220,215,176);stop-opacity:1.00" />
+<stop offset="80.00%" style="stop-color:rgb(184,89,167);stop-opacity:1.00" />
+<stop offset="100.00%" style="stop-color:rgb(57,66,154);stop-opacity:1.00" />
+</linearGradient>
+<path fill="url(#6131A9E2-CA9E-49F0-9B44-3AD4FEE82BAF_0)" fill-rule="evenodd" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M 487.836 351.316 C 490.906 312.703 545.857 387.302 583.305 377.404 C 623.800 366.701 618.917 287.266 658.425 301.178 C 712.010 320.046 630.842 413.063 574.402 419.539 C 531.546 424.457 483.200 409.643 487.836 351.316 M 749.045 321.028 C 683.912 250.563 639.338 271.445 542.736 188.564 C 508.245 158.972 407.385 204.877 438.081 321.005 C 459.406 401.683 442.008 458.941 505.727 493.760 C 606.354 548.747 843.850 423.595 749.045 321.028 Z"/>
+</svg>

--- a/demos/cpp/gradient-circle/gradient-circle_00240.svg
+++ b/demos/cpp/gradient-circle/gradient-circle_00240.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Moho 12.4 build 22203 -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Frame_240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1280px" height="720px">
+<linearGradient id="6131A9E2-CA9E-49F0-9B44-3AD4FEE82BAF_0" x1="52.03%" y1="96.84%" x2="68.26%" y2="-5.08%">
+<stop offset="0.00%" style="stop-color:rgb(45,44,44);stop-opacity:1.00" />
+<stop offset="78.43%" style="stop-color:rgb(247,96,99);stop-opacity:1.00" />
+<stop offset="100.00%" style="stop-color:rgb(255,255,255);stop-opacity:1.00" />
+</linearGradient>
+<path fill="url(#6131A9E2-CA9E-49F0-9B44-3AD4FEE82BAF_0)" fill-rule="evenodd" stroke="#000000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="M 520.841 421.639 C 548.478 401.401 544.897 347.042 578.104 355.449 C 623.113 366.844 619.726 441.234 586.607 473.774 C 546.710 512.975 442.083 510.383 444.997 454.526 C 446.682 422.215 494.737 440.754 520.841 421.639 M 659.737 406.476 C 666.706 338.047 609.767 199.769 524.724 293.970 C 488.643 333.936 473.574 363.641 405.652 362.883 C 352.736 362.292 373.991 463.970 414.691 497.795 C 495.249 564.743 649.368 508.298 659.737 406.476 Z"/>
+</svg>

--- a/demos/cpp/main.cpp
+++ b/demos/cpp/main.cpp
@@ -1,0 +1,62 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+#include <string>
+#include <fstream>
+#include <sstream>
+
+#include "graphics.h"
+
+std::string fileToString(const char *filePath) {
+    std::ifstream input(filePath);
+
+    std::stringstream buffer;
+    buffer << input.rdbuf();
+
+    return buffer.str();
+}
+
+tove::GraphicsRef graphicsFromFile(const char *filePath) {
+    const auto svg = fileToString(filePath);
+
+    return tove::Graphics::createFromSVG(svg.c_str(), "px", 100);
+}
+
+int rasterizeToFile(tove::Graphics &graphics, const char *outputFilePath) {
+    const float *bounds = graphics.getExactBounds();
+
+    const int x1 = bounds[0];
+    const int y1 = bounds[1];
+    const int x2 = bounds[2];
+    const int y2 = bounds[3];
+
+    const int width = x2 - x1;
+    const int height = y2 - y1;
+
+    std::vector<uint8_t> pixels(width * height * 4);
+
+    graphics.rasterize(pixels.data(), width, height, width * 4, - x1, - y1, 1);
+
+    return stbi_write_png(outputFilePath, width, height, 4, pixels.data(), width * 4);
+}
+
+int main() {
+    auto svg1 = graphicsFromFile("gradient-circle/gradient-circle_00001.svg");
+    auto svg2 = graphicsFromFile("gradient-circle/gradient-circle_00240.svg");
+
+    tove::Graphics target;
+
+    static const int frameCount = 8;
+
+    for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
+        const float t = static_cast<float>(frameIndex) / frameCount;
+
+        target.animate(svg1, svg2, t);
+
+        const auto frameFileName = "frames/" + std::to_string(frameIndex) + ".png";
+
+        rasterizeToFile(target, frameFileName.c_str());
+    }
+
+    return 0;
+}

--- a/demos/cpp/main.cpp
+++ b/demos/cpp/main.cpp
@@ -49,7 +49,7 @@ int main() {
     static const int frameCount = 8;
 
     for (int frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
-        const float t = static_cast<float>(frameIndex) / frameCount;
+        const float t = static_cast<float>(frameIndex) / (frameCount - 1);
 
         target.animate(svg1, svg2, t);
 


### PR DESCRIPTION
This PR adds a demo that shows how to render an SVG animation to PNG files from C++ code.

I made this because I want to use TÖVE's flipbooks outside of LÖVE (inside SDL / OpenGL applications).

The demo appears to work, but I'm not sure if the code is correct. 

Feel free to close this PR if you think that TÖVE shouldn't be used in this manner, or for whatever reason.