### PR TITLE
`GraphicsGetBounds` returns valid struct data

### DIFF
--- a/src/cpp/interface/api.cpp
+++ b/src/cpp/interface/api.cpp
@@ -830,7 +830,7 @@ void GraphicsStroke(ToveGraphicsRef shape) {
 	deref(shape)->stroke();
 }
 
-ToveBounds GraphicsGetBounds(ToveGraphicsRef shape, bool exact) {
+void GraphicsGetBounds(ToveGraphicsRef shape, bool exact, ToveBounds *bounds) {
 	const float *computed;
 
 	if (exact) {
@@ -839,12 +839,10 @@ ToveBounds GraphicsGetBounds(ToveGraphicsRef shape, bool exact) {
 		computed  = deref(shape)->getBounds();
 	}
 
-	ToveBounds bounds;
-	bounds.x0 = computed[0];
-	bounds.y0 = computed[1];
-	bounds.x1 = computed[2];
-	bounds.y1 = computed[3];
-	return bounds;
+	bounds->x0 = computed[0];
+	bounds->y0 = computed[1];
+	bounds->x1 = computed[2];
+	bounds->y1 = computed[3];
 }
 
 void GraphicsSet(

--- a/src/cpp/interface/api.h
+++ b/src/cpp/interface/api.h
@@ -130,7 +130,7 @@ EXPORT void GraphicsSetLineDash(ToveGraphicsRef shape, const float *dashes, int 
 EXPORT void GraphicsSetLineDashOffset(ToveGraphicsRef shape, float offset);
 EXPORT void GraphicsFill(ToveGraphicsRef shape);
 EXPORT void GraphicsStroke(ToveGraphicsRef shape);
-EXPORT ToveBounds GraphicsGetBounds(ToveGraphicsRef shape, bool exact);
+EXPORT void GraphicsGetBounds(ToveGraphicsRef shape, bool exact, ToveBounds *bounds);
 EXPORT void GraphicsSet(ToveGraphicsRef graphics, ToveGraphicsRef source,
 	bool scaleLineWidth, float a, float b, float c, float d, float e, float f);
 EXPORT void GraphicsRasterize(ToveGraphicsRef shape, uint8_t *pixels,

--- a/src/lua/graphics.lua
+++ b/src/lua/graphics.lua
@@ -424,7 +424,8 @@ bind("stroke", "GraphicsStroke")
 -- @treturn number y1 (bottom-most y)
 
 function Graphics:computeAABB(prec)
-	local bounds = lib.GraphicsGetBounds(self._ref, prec == "high")
+	local bounds = ffi.new("ToveBounds")
+	lib.GraphicsGetBounds(self._ref, prec == "high", bounds)
 	return bounds.x0, bounds.y0, bounds.x1, bounds.y1
 end
 
@@ -434,7 +435,8 @@ end
 -- @see computeAABB
 
 function Graphics:getWidth(prec)
-	local bounds = lib.GraphicsGetBounds(self._ref, prec == "high")
+	local bounds = ffi.new("ToveBounds")
+	lib.GraphicsGetBounds(self._ref, prec == "high", bounds)
 	return bounds.x1 - bounds.x0
 end
 
@@ -444,7 +446,8 @@ end
 -- @see computeAABB
 
 function Graphics:getHeight(prec)
-	local bounds = lib.GraphicsGetBounds(self._ref, prec == "high")
+	local bounds = ffi.new("ToveBounds")
+	lib.GraphicsGetBounds(self._ref, prec == "high", bounds)
 	return bounds.y1 - bounds.y0
 end
 


### PR DESCRIPTION
When called from the Lua API, the `GraphicsGetBounds` function was returning garbage values in the `ToveBounds` struct, even though the struct's values in C++ were correct. This meant that any functionality relying on the `computeAABB` method (namely rescaling and `texture` renderers) would silently do/draw nothing.

Fix this bug by having the Lua API pass a `ToveBounds` struct to `GraphicsGetBounds` by reference, so the struct values accessed after calling the function are always valid.

---

Tested this on an arm64 Mac (Sonoma 14.7.2) and Löve version 11.5 on the `blob` demo:

Before fix             |  After fix
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e821b0bc-e2c6-4c1e-98d9-8ade0cfdd494)  |  ![](https://github.com/user-attachments/assets/72823efb-34a9-4391-ab1d-d7ff5502b16b)

